### PR TITLE
Remove redundant var_dump expressions

### DIFF
--- a/src/BreathTakinglyBinary/DynamicBossBar/BossBar.php
+++ b/src/BreathTakinglyBinary/DynamicBossBar/BossBar.php
@@ -291,7 +291,6 @@ class BossBar{
         $pk->entityRuntimeId = $this->entityId;
         $pk->type = $this->getEntity() instanceof Entity ? $this->getEntity()::NETWORK_ID : static::NETWORK_ID;
         $pk->attributes = $this->getAttributeMap()->getAll();
-        var_dump($this->getPropertyManager()->getAll());
         $pk->metadata = $this->getPropertyManager()->getAll();
         foreach($players as $player){
             $pkc = clone $pk;

--- a/src/BreathTakinglyBinary/DynamicBossBar/DiverseBossBar.php
+++ b/src/BreathTakinglyBinary/DynamicBossBar/DiverseBossBar.php
@@ -168,7 +168,6 @@ class DiverseBossBar extends BossBar{
             $pkc = clone $pk;
             $pkc->attributes = $this->getAttributeMap($player)->getAll();
             $pkc->metadata = $this->getPropertyManager($player)->getAll();
-            #var_dump($this->getPropertyManager()->getAll());
             $pkc->position = $player->asVector3()->subtract(0, 28);
             $player->dataPacket($pkc);
         }

--- a/virion.yml
+++ b/virion.yml
@@ -1,5 +1,5 @@
 name: DynamicBossBar
-version: 0.0.4
+version: 0.0.5
 antigen: BreathTakinglyBinary\DynamicBossBar
 api: [3.9, 4.0.0]
 php: [7.2]


### PR DESCRIPTION
Very basic PR that intends to remove the `var_dump` expressions from the `sendSpawnPacket()` methods in the `BossBar` and `DiverseBossBar` classes.